### PR TITLE
build: prepare for v0.1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool converts PLEXOS input XML files and their associated data into PyPSA n
 ## Requirements
 
 - **Python**: 3.11 or 3.12
-- **PyPSA**: Version <1.0 (specifically >=0.34, <1.0)
+- **PyPSA**: Version >= 1.0.4
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "plexos-to-pypsa-converter"
-version = "0.1.0"
+version = "0.1.1"
 description = "PLEXOS-to-PyPSA Converter"
 readme = "README.md"
 classifiers = [


### PR DESCRIPTION
Closes:
- #110 

Bump version to v0.1.1 and update PyPSA package requirement to `>= v1.0.4` in `README`. 

Release notes to be added to Github release:
- **Auto-detection of input model features**: workflows now discover PLEXOS features automatically; registry step lists were removed and examples/tests updated to use auto-build paths
- **Custom input path support**: workflows accept custom model/csv paths instead of only allowing conversion of supported sample models
- **Dependency changes**: PyPSA dependency raised to >=1.0.4 (pyproject.toml, workflow defaults), with converter issues related to running on PyPSA >= 1 fixed
- **Generator/ramp stability fixes**: ramp smoothing applied before unit retirements (prevents infeasibilities)
- **Documentation**: added notebook presented in Rome December workshop